### PR TITLE
Small changes / fixes.

### DIFF
--- a/fuckyoutube_pure.py
+++ b/fuckyoutube_pure.py
@@ -1,28 +1,37 @@
 import requests
 import re
+import json
+
+def detect_schema(link):
+    if link.startswith('http://') or link.startswith('https://'):
+        return link  # return as-is if schema already supplied
+
+    response = requests.head('http://' + link)
+    if response.status_code == 200:
+        return 'http://' + link  # if successful as http, it's http
+    else:
+        return 'https://' + link  # if not, it's https
 
 def get_direct_link(youtube_url):
     try:
         response = requests.get(youtube_url)
-        if response.status_code == 200:
-            match = re.search(r'"url":"(https://[^"]+)"', response.text)
-            if match:
-                direct_link = match.group(1)
-                return direct_link
-            else:
-                return "not found"
+        response.raise_for_status()  # Raise an exception for non-2xx status codes
+        match = re.search(r'"url":"(https://[^"]+googlevideo[^"]+)"', response.text)  # only get video URLs
+        if match:
+            direct_link = json.loads(f'"{match.group(1)}"')  # Decode escape sequences
+            return direct_link
         else:
-            return f"failed to fetch the youtube page (http {response.status_code})."
-    except Exception as e:
-        return str(e)
+            return "not found"
+    except requests.exceptions.RequestException as e:
+        return f"Failed to fetch the YouTube page: {str(e)}"
 
 if __name__ == "__main__":
-    youtube_url = input("url: ")
-    
-    direct_link = get_direct_link(youtube_url)
-    
+    youtube_url = input("Enter the YouTube URL: ")
+
+    direct_link = get_direct_link(detect_schema(youtube_url))
+
     if direct_link:
-        print("direct link:")
+        print("Direct link:")
         print(direct_link)
     else:
-        print("could not retrieve")
+        print("Could not retrieve the direct link.")


### PR DESCRIPTION
- Added functionality for detecting URL Schema if it's not already supplied
- Raises connection errors for all status code(s) instead of hard-coding it to `200`
- Reconfigured Regex to search for `googlevideo` just instances, as before it'd always hit something thus resulting in no error being thrown even if the URL was invalid.
- Loads the generated link using the `.match()` functionality of the `json` library to parse any escape sequences.
- Minor formatting changes.